### PR TITLE
Refreshing rules for 2024, including discord discussion of new mods

### DIFF
--- a/wiki/posting-guidelines-and-rules-explanation/README.md
+++ b/wiki/posting-guidelines-and-rules-explanation/README.md
@@ -1,93 +1,105 @@
 # Posting Guidelines and Rules Explanation
 
-Community / Posting Rules
+## Community / Posting Rules
 
-I | Real space images only.
+(to be moved to position #2 so the Post Types rule can be #1 and set the stage for allowable post types before we get into how imaging posts will work)
 
-* Astrophotography refers to images of astronomical objects or phenomena exclusively.
-* Images that show objects or people below the Kármán Line (100km) will be removed.
-* Images must be an accurate representation of a real astronomical object.
-* Equipment posts are allowed
-* Photos taken while the photographer is above the Kármán Line are allowed
+Rule 2: Real Astrophotography and Equipment Images Only
 
-II | Original and Amateur Content Only
+* Astrophotography refers to images of astronomical objects or phenomena exclusively. We define this to mean objects that are at or above the Kármán Line (boundary separating Earth’s atmosphere and outer space).
+* Images must be an accurate representation of a real astronomical object. No AI-generated, artistic representations, memes, man-made objects, or composites of astronomical objects along with annotations or other images will be allowed.
+* Images that include landscape in the foreground will be permitted as long as it is a small portion of the overall image and the astronomical objects are the primary focus and follow the other rules. Images with people or buildings will not be permitted. Such images must include flair 'Landscape'.
+* Images captured by cell phone will be permitted as long as they are not low-effort and follow the other rules, including acqusition/processing details. Simple starfield images without an obvious focus on an astronomical object besides individual stars, or casual single-shot images will not be permitted.
+* Equipment posts are allowed as long as they are of the equipment alone and the 'Equipment' flair has been applied.
+* All other images will be removed. 
 
-* Image posts can only be images that you have captured and processed yourself, or discussion about capturing and/or processing your own images.
-* Images acquired from public sources, professional observatories, or other professional services are not allowed.
+(to be moved)
+
+Rule 3: Original and Amateur Content Only
+
+* Image posts can only be images that you have captured and processed yourself, or discussion about an image you are posting that you have captured and/or processed yourself.
+* Images acquired from public sources, professional observatories, other professional services, or anyone other than yourself are not allowed.
 * If you have done a drastic alteration or reprocessing of a prior submission, you may repost your edit - but only after a minimum of one week has passed.
 
-III | Post Types
+(to be moved)
 
-* Image posts are to link directly to the image, not to landing pages, personal galleries, blogs, or professional sites. Link to these in the comments. (AstroBin and Imgur, are allowed)
-* Links to blogs, articles or external websites should be interesting and promote discussion about amateur astrophotography.
-* Questions should be posted to our sister subreddit, /r/AskAstrophotography.
+Rule 1: Post Types
 
-IV | Titles
+* Image posts must be embedded as part of the post itself and not linked to external sites, with the exception of Astrobin. When sharing via Astrobin, the link must go directly to the image, not to landing pages, personal galleries, blogs, or other professional sites. Videos that follow the other rules are permitted as long as they are embedded in the post and not linked to external sites.
+* Links to blogs, articles or external websites must be interesting and promote discussion about amateur astrophotography. Self-promotion is not permitted. Discussion posts must be have flair set to 'Discussion' to avoid removal.
+* Questions are permitted if they are regarding and accompany an allowed astrophotography image, but all other questions are not permitted and should be posted to our sister subreddit, /r/AskAstrophotography.
 
-* All image posts should include the name of the object being photographed in the title, and it should not be 'clickbaity' or excessive.
-* It should not be a list of your equipment. Posts with titles like these will be removed. If your post is removed, try reposting with a different title.
+Rule 4: Titles
+
+* All astrophotography object image posts must include the name of the object being photographed in the title, and it must not be 'clickbaity' or excessive.
+* Do not indicate the equipment used, acqusition details, processing details, or other superfluous information in the title. Instead, these details should be in the body of the post or a comment made immediately after posting.
 * [See this page for more details.](post-titles.md)
+* Posts with titles that deviate from these rules will be removed. If your post is removed, try reposting with a different title.
+* Posts with flair 'Equipment' or 'Discussion' have no specific rules regarding title format other than also not being 'clickbaity'.
 
-V | Acquisition and Processing Information
+Rule 5: Acquisition and Processing Information
 
-* All submitted images must include acquisition and processing details as a top-level comment. All posts without this information will be removed after a period of time. Posts with partial details (i.e. no processing info) may be given a warning, and if not updated will be removed.
-* This includes the telescope, mount, camera, accessories, and any other pieces of equipment you used to capture the image.
-* You must also include processing details, i.e. the programs you used and a general rundown of the workflow/processes you used within those programs. “Processed in Photoshop” is not enough.
+* All astrophotography object image posts must include acquisition and processing details as a top-level comment. All such posts without this information will be removed after a period of time. Posts with partial details (i.e. no processing info) may be given a warning, and if not updated will be removed.
+* Acquisition details include the telescope, mount, camera, accessories, and any other pieces of equipment you used to capture the image, as well as number and exposure of subs.
+* Processing details include the programs you used and a general rundown of the workflow/processes you used within those programs. “Processed in Photoshop” is not enough.
 
-Posting etiquette:
+Rule 6: General Etiquette
 
-* Please follow these rules to the best of your ability - please keep discussion on topic and treat each other with respect. Go to /r/AskAstrophotography if you have questions. Keep memes and politics off the sub. This community encourages and welcomes constructive criticism of images. If you think an OP can improve in any way please don't be shy and speak up!
+* Keep discussion on topic and focused on astrophotography. No discussions regarding politics, religion, UFOs, conspiracy theories, or other non-astrophotography topics will be permitted.
+* Treat each other with respect. 
+* This community encourages and welcomes constructive criticism of images. If you think an OP can improve in any way please don't be shy and speak up!
 
-### Rules Explained
+## Rules Explained
 
-Here we have a more detailed explanation of the rules than that found in the sidebar. This hopefully gives some insight and understanding as to why these rules are in place. Believe it or not, we moderators don't just remove things for the sake of having something to do, we do it to try and keep a standard level of quality in the content which is posted to the community.
+Here we have a more detailed explanation of the rules than that found in the sidebar. This hopefully gives some insight and understanding as to why these rules are in place. Believe it or not, we moderators don't just remove things for the sake of having something to do -- we do it to try and keep a standard level of quality in the content which is posted to the community.
 
-Rule 1:
-
-* Astrophotography refers to images of astronomical objects or phenomena exclusively. Images which show objects or people below the Kármán Line (100km) will be removed. This includes buildings, planes, rockets, or other man-made objects. This includes people. Terrain in wide field images should be cropped out. If the photographer themselves is above the Kármán Line while taking their photo, it may be posted even if it contains terrestrial or man-made objects.
-* In addition, only real astronomical images may be posted. This excludes phenomenon which are impossible to image, such as superimposing the moon over random star fields, animated deep sky objects, combining different phases of the moon, etc. In essence, images should be an accurate representation of the object. Equipment posts are allowed and encouraged!
-
-> This rule was enacted in order to keep the community focused more on the astrophotography and less focused on artsy lit-foregrounds of dead trees and barns. While we may allow certain wide field shots they should be able to stand on the merit of the astrophotography alone and any terrain left in should be either extremely unobtrusive, or necessary to show the astronomical object, for example an eclipse that is extremely low in the sky and would otherwise be blocked by trees. That said, images should be cropped avoid terrestrial objects. This rule also applies to "faked" images depicting phenomenon which are physically impossible to capture on film, [such as animated deep-sky pictures](https://gfycat.com/linearevendrever-space), or the moon superimposed over star trails. In essence, images should be an accurate representation of the object.
-
-***
-
+(will move to correct position later)
 Rule 2:
 
-* Posts can only be images that you have captured and processed yourself, or discussion about capturing and processing your own images. Images acquired by professional equipment or professional services are not allowed. This includes iTelescope, Deep Sky West, DCT, and similar services. It is however acceptable to post images taken by remote equipment when you are the sole person who owns and operates the equipment. Posts showing off your equipment are allowed and encouraged.
+* Astrophotography refers to images of real astronomical objects or phenomena.
+* Landscape and cell phone images will be permitted as long as the focus is on astronomical objects (not just stars), are not low-effort, and follow all other rules.
+* Equipment posts are allowed and encouraged
 
-> A part of the original goal of this community is constructive feedback on images, and that goal is negated by a poster who hasn't actually made the image they have submitted as they will not be able to reply or take this into account. Additionally, you are essentially stealing someone elses work just for Karma. This is wrong and looked down upon here. Similarly, discussion should be kept on-topic. Memes and shitposts aren't allowed (come to our [Discord](https://discord.com/invite/4vYBMVd) for that).
->
-> The time limit on reposting an edited version of a submission you made is to keep people from spamming the sub with 18 different versions of the same picture. We would love to see your edit, all we ask is that you wait before posting it. If you made an edit and found your image to be better immediately following your post to the sub, feel free to delete the first post and repost.
->
-> This is the only dedicated amateur-only community. There are countless other space-related communities that let you post an image you found online.
+> This rule was enacted in order to keep the community focused more on the astrophotography and less focused on artsy lit-foregrounds of dead trees and barns. While we may allow certain wide field shots they should be able to stand on the merit of the astrophotography alone and any terrain left in should be either extremely unobtrusive, or necessary to show the astronomical object, for example an eclipse that is extremely low in the sky and would otherwise be blocked by trees. That said, images should generally be cropped to avoid terrestrial objects. This rule also applies to "faked" images depicting phenomenon which are physically impossible to capture on film, [such as animated deep-sky pictures](https://gfycat.com/linearevendrever-space), or the moon superimposed over star trails. In essence, images should be an accurate representation of the object.
+> Images captured with cell phones will be permitted, but only if they follow the rest of the rules of this sub, and clearly represent real effort. While individual shots of a generic starry sky may technically be "astrophotography", they are not broadly interesting to this community. At the same time we recognize that many people get started in this hobby with a cell phone on a tripod using stacking and processing apps on that device, so as long as there's a clear astronomical target represented in the image and all other rules are followed, they are welcome here.
 
 ***
+
+(will move to correct position later)
 
 Rule 3:
 
-* Image posts should link directly to the image, not to landing pages, personal galleries, or professional sites. Submissions that link to professional photography sites, or gallery/feed based services or pages (such as Fotki, Flickr, or 500px's landing pages) are not allowed. We prefer Imgur or Astrobin. Links to such pages are allowed in the comments section.
+* Original OC and amateur images only
 
-> This is down to image visibility and usability of landing pages and various websites in browser or in mobile apps. Direct links to the image work best across all devices, so is preferred. In addition it allows the platform to display the images without leaving the website, and allows our users to avoid off-site advertisements and bad website design.
+> A major objective of this community is to foster constructive feedback on images, and that goal is negated by a poster who hasn't actually made the image they have submitted as they will not be able to reply or take feedback into account. This is the only dedicated amateur-only community. There are countless other space-related communities that let you post an image you found online.
 
-* Links to blogs, articles or external websites should be interesting and promote discussion about astrophotography. Posts of this type that do not encourage discussion will be removed. This includes the promotion of items for sale within your posts as well (there are other communities for that). Similarly, excessively advertising your own website or page is not allowed and will be removed as spam. Take these things to the comments if you desire, there are no rules (within reason) of what you can share in your required information comment.
+> The time limit on reposting an edited version of a submission you made is to keep people from spamming the sub with 18 different versions of the same picture. We would love to see your edit, all we ask is that you wait before posting it. If you made an edit and found your image to be better immediately following your post to the sub, feel free to delete the first post and repost.
 
-> This is primarily a community about imaging, so we prefer to keep non-image posts out of the main page unless they are something thoughtful and thought provoking. General news and new product releases are not usually allowed, and simple/beginner questions (e.g. "should I get this telescope") should be asked in /r/AskAstrophotography, or our [discord](https://discord.com/invite/4vYBMVd) chat.
+***
+
+(will move to correct position later)
+
+Rule 1:
+
+* Types of posts in general
+
+> This sub celebrates amateur astrophotography and will primarily focus on sharing and discussing the work of our members. We're allowing discussion of astrophotography articles as long as they're interesting and promote discussion about astrophotography, but promotion of items for sale or self-promootion of your own website or other extenral channels falls outside of this and will be removed as spam. Equipment posts are allowed in order to allow our members to get feedback about their gear and help others to learn what works well for this hobby. Simple/beginner questions (e.g. "should I get this telescope") should be asked in /r/AskAstrophotography.
+
+* Directly embedded images and links to Astrobin
+
+> This is down to image visibility and usability. Embedding images in the post makes it easier for both mobile and desktop users to view without leaving Reddit, and allows our users to avoid off-site advertisements and bad website design. Astrobin in particular is permitted to be linked to because astrophotographers often include considerable additional detail about their work there, but links must be to the specific object page so users can view it without effort. 
 
 ***
 
 Rule 4:
 
-* All posts must contain the name of the subject in the image, and karma-bait titles are not allowed. Posts with these infractions will be subject to the discretion of a moderator for a warning or removal.
-* All image posts should include the name of the object being photographed in the title, and it should not be 'clickbaity' or excessive.
-* It should not be a list of your equipment. Posts with titles like these will be removed. If your post is removed, try reposting with a different title.
-* [See this page for more details.](post-titles.md)
-
-> Simply put, bad titles are annoying. We want to encourage users to upvote posts based on the quality of the image, not the story the title tells. This hopefully leads to better images getting the recognition they deserve. While this may not always appear to work in practice, it has helped significantly over the period it has been in place. Stories about the images belong in the comments section along with your acquisition and processing details, not in the title. Also please keep your list of equipment in a comment on your post per rule 5
+* Titles
+> Simply put, bad titles are annoying. We want to encourage users to upvote posts based on the quality of the image, not the story the title tells. This hopefully leads to better images getting the recognition they deserve. While this may not always appear to work in practice, it has helped significantly over the period it has been in place. Stories about the images belong in the comments section along with your acquisition and processing details, not in the title. Also please keep your list of equipment in a comment on your post per rule 5.
 
 ***
 
 Rule 5:
 
-* All submitted images MUST include acquisition AND processing details as a top-level comment. If no details are added after a reasonable period of time the post will be removed. Posts with partial details (i.e. no processing info, incomplete equipment list, etc.) may be given a warning, and if not updated will be removed.
+* Acquisition and Processing Details
 
-> Acquisition and processing details are important for much the same reason given in rule 2; you can't give feedback, new users can't research equipment or replicate the image, and discussion is reduced and simplified as a consequence. We don't want to see an image with a bunch of posts saying "nice" in the comments, we want to see "nice, but this could have been done differently". Acquisition details refers to any hardware used (i.e. telescope, mount, camera), the exposure count/length, and software used for hardware control (e.g. PHD2, backyardEOS). Processing details refer to software used to stack and edit the images (e.g. deepskystacker, pixinsight), and, at a minimum, a basic rundown of processes done. While we don't expect exact number settings for a pixinsight process we do expect the process itself to be mentioned. Posts will be removed without warning if no details have been added after a reasonable amount of time has passed. We know that if you processed an image, you probably used one of several processing programs such as Pixinsight or Photoshop, Gimp, etc, to name a few. We want to know what you _did_. Simply saying "processed in PixInsight" is like saying I breathe air. It doesn't add anything to discuss.
+> Acquisition and processing details are important for much the same reason given in rule 3; you can't give feedback, new users can't research equipment or replicate the image, and discussion is reduced and simplified as a consequence. We don't want to see an image with a bunch of posts saying "nice" in the comments -- we want to see "nice, but this could have been done differently". Acquisition details refers to any hardware used (i.e. telescope, mount, camera), the exposure count/length, and software used for hardware control (e.g. PHD2, backyardEOS). Processing details refer to software used to stack and edit the images (e.g. deepskystacker, PixInsight), and, at a minimum, a basic rundown of processes done. While we don't expect exact number settings for a PixInsight process we do expect the process itself to be mentioned. Posts will be removed without warning if no details have been added after a reasonable amount of time has passed. We know that if you processed an image, you probably used one of several processing programs such as PixInsight or Photoshop, Gimp, etc, to name a few. We want to know what you _did_. Simply saying "processed in PixInsight" is like saying I breathe air. It doesn't add anything to discuss.

--- a/wiki/posting-guidelines-and-rules-explanation/README.md
+++ b/wiki/posting-guidelines-and-rules-explanation/README.md
@@ -2,9 +2,17 @@
 
 ## Community / Posting Rules
 
-(to be moved to position #2 so the Post Types rule can be #1 and set the stage for allowable post types before we get into how imaging posts will work)
+### Rule 1: Post Types
 
-Rule 2: Real Astrophotography and Equipment Images Only
+* Image posts must be embedded as part of the post itself and not linked to external sites, with the exception of Astrobin. When sharing via Astrobin, the link must go directly to the image, not to landing pages, personal galleries, or blogs; no other sites are permitted. Videos that follow the other rules are permitted as long as they are embedded in the post and not linked to external sites.
+* Links to blogs, articles or external websites must be interesting and promote discussion about amateur astrophotography. Self-promotion is not permitted. Discussion posts must be have flair set to 'Discussion' to avoid removal.
+* Questions are permitted if they are regarding and accompany an allowed astrophotography image, but all other questions are not permitted and should be posted to our sister subreddit, /r/AskAstrophotography.
+
+> This sub celebrates amateur astrophotography and will primarily focus on sharing and discussing the work of our members. We're allowing discussion of astrophotography articles as long as they're interesting and promote discussion about astrophotography, but promotion of items for sale or self-promootion of your own website or other extenral channels falls outside of this and will be removed as spam. Equipment posts are allowed in order to allow our members to get feedback about their gear and help others to learn what works well for this hobby. Simple/beginner questions (e.g. "should I get this telescope") should be asked in /r/AskAstrophotography.
+
+> Embedding images in the post makes it easier for both mobile and desktop users to view without leaving Reddit, and allows our users to avoid off-site advertisements and bad website design. Astrobin in particular is permitted to be linked to because astrophotographers often include considerable additional detail about their work there, but links must be to the specific object page so users can view it without effort.
+
+### Rule 2: Real Astrophotography and Equipment Images Only
 
 * Astrophotography refers to images of astronomical objects or phenomena exclusively. We define this to mean objects that are at or above the Kármán Line (boundary separating Earth’s atmosphere and outer space).
 * Images must be an accurate representation of a real astronomical object. No AI-generated, artistic representations, memes, man-made objects, or composites of astronomical objects along with annotations or other images will be allowed.
@@ -13,93 +21,40 @@ Rule 2: Real Astrophotography and Equipment Images Only
 * Equipment posts are allowed as long as they are of the equipment alone and the 'Equipment' flair has been applied.
 * All other images will be removed. 
 
-(to be moved)
+> This rule was enacted in order to keep the community focused more on the astrophotography and less focused on artsy lit-foregrounds of dead trees and barns. While we may allow certain wide field shots they should be able to stand on the merit of the astrophotography alone and any terrain left in should be either extremely unobtrusive, or necessary to show the astronomical object, for example an eclipse that is extremely low in the sky and would otherwise be blocked by trees. That said, images should generally be cropped to avoid terrestrial objects. This rule also applies to "faked" images depicting phenomenon which are physically impossible to capture on film, [such as animated deep-sky pictures](https://gfycat.com/linearevendrever-space), or the moon superimposed over star trails. In essence, images should be an accurate representation of the object.
 
-Rule 3: Original and Amateur Content Only
+> Images captured with cell phones will be permitted, but only if they follow the rest of the rules of this sub, and clearly represent real effort. While individual shots of a generic starry sky may technically be "astrophotography", they are not broadly interesting to this community. At the same time we recognize that many people get started in this hobby with a cell phone on a tripod using stacking and processing apps on that device, so as long as there's a clear astronomical target represented in the image and all other rules are followed, they are welcome here.
+
+### Rule 3: Original and Amateur Content Only
 
 * Image posts can only be images that you have captured and processed yourself, or discussion about an image you are posting that you have captured and/or processed yourself.
 * Images acquired from public sources, professional observatories, other professional services, or anyone other than yourself are not allowed.
 * If you have done a drastic alteration or reprocessing of a prior submission, you may repost your edit - but only after a minimum of one week has passed.
 
-(to be moved)
+> A major objective of this community is to foster constructive feedback on images, and that goal is negated by a poster who hasn't actually made the image they have submitted as they will not be able to reply or take feedback into account. This is the only dedicated amateur-only community. There are countless other space-related communities that let you post an image you found online.
 
-Rule 1: Post Types
+> The time limit on reposting an edited version of a submission you made is to keep people from spamming the sub with 18 different versions of the same picture. We would love to see your edit, all we ask is that you wait before posting it. If you made an edit and found your image to be better immediately following your post to the sub, feel free to delete the first post and repost.
 
-* Image posts must be embedded as part of the post itself and not linked to external sites, with the exception of Astrobin. When sharing via Astrobin, the link must go directly to the image, not to landing pages, personal galleries, blogs, or other professional sites. Videos that follow the other rules are permitted as long as they are embedded in the post and not linked to external sites.
-* Links to blogs, articles or external websites must be interesting and promote discussion about amateur astrophotography. Self-promotion is not permitted. Discussion posts must be have flair set to 'Discussion' to avoid removal.
-* Questions are permitted if they are regarding and accompany an allowed astrophotography image, but all other questions are not permitted and should be posted to our sister subreddit, /r/AskAstrophotography.
-
-Rule 4: Titles
+### Rule 4: Post Titles
 
 * All astrophotography object image posts must include the name of the object being photographed in the title, and it must not be 'clickbaity' or excessive.
 * Do not indicate the equipment used, acqusition details, processing details, or other superfluous information in the title. Instead, these details should be in the body of the post or a comment made immediately after posting.
-* [See this page for more details.](post-titles.md)
+* [See this page for examples of good and bad titles.](post-titles.md)
 * Posts with titles that deviate from these rules will be removed. If your post is removed, try reposting with a different title.
 * Posts with flair 'Equipment' or 'Discussion' have no specific rules regarding title format other than also not being 'clickbaity'.
 
-Rule 5: Acquisition and Processing Information
+> Simply put, bad titles are annoying. We want to encourage users to upvote posts based on the quality of the image, not the story the title tells. This hopefully leads to better images getting the recognition they deserve. While this may not always appear to work in practice, it has helped significantly over the period it has been in place. Stories about the images belong in the comments section along with your acquisition and processing details, not in the title. Also please keep your list of equipment in a comment on your post per rule 5.
+
+### Rule 5: Acquisition and Processing Information
 
 * All astrophotography object image posts must include acquisition and processing details as a top-level comment. All such posts without this information will be removed after a period of time. Posts with partial details (i.e. no processing info) may be given a warning, and if not updated will be removed.
 * Acquisition details include the telescope, mount, camera, accessories, and any other pieces of equipment you used to capture the image, as well as number and exposure of subs.
 * Processing details include the programs you used and a general rundown of the workflow/processes you used within those programs. “Processed in Photoshop” is not enough.
 
-Rule 6: General Etiquette
+> Acquisition and processing details are important for much the same reason given in rule 3; the community can't give feedback, new users can't research equipment or replicate the image, and discussion is reduced and simplified as a consequence. We don't want to see an image with a bunch of posts saying "nice" in the comments -- we want to see "nice, but this could have been done differently". Acquisition details refers to any hardware used (i.e. telescope, mount, camera), the exposure count/length, and software used for hardware control (e.g. PHD2, backyardEOS). Processing details refer to software used to stack and edit the images (e.g. deepskystacker, PixInsight), and, at a minimum, a basic rundown of processes done. While we don't expect exact number settings for a PixInsight process, we do expect the process itself to be mentioned. Posts will be removed without warning if no details have been added after a reasonable amount of time has passed. We know that if you processed an image, you probably used one of several processing programs such as PixInsight or Photoshop, Gimp, etc, to name a few. We want to know what you _did_. Simply saying "processed in PixInsight" is like saying I breathe air. It doesn't add anything to discuss.
+
+### Rule 6: General Etiquette
 
 * Keep discussion on topic and focused on astrophotography. No discussions regarding politics, religion, UFOs, conspiracy theories, or other non-astrophotography topics will be permitted.
 * Treat each other with respect. 
 * This community encourages and welcomes constructive criticism of images. If you think an OP can improve in any way please don't be shy and speak up!
-
-## Rules Explained
-
-Here we have a more detailed explanation of the rules than that found in the sidebar. This hopefully gives some insight and understanding as to why these rules are in place. Believe it or not, we moderators don't just remove things for the sake of having something to do -- we do it to try and keep a standard level of quality in the content which is posted to the community.
-
-(will move to correct position later)
-Rule 2:
-
-* Astrophotography refers to images of real astronomical objects or phenomena.
-* Landscape and cell phone images will be permitted as long as the focus is on astronomical objects (not just stars), are not low-effort, and follow all other rules.
-* Equipment posts are allowed and encouraged
-
-> This rule was enacted in order to keep the community focused more on the astrophotography and less focused on artsy lit-foregrounds of dead trees and barns. While we may allow certain wide field shots they should be able to stand on the merit of the astrophotography alone and any terrain left in should be either extremely unobtrusive, or necessary to show the astronomical object, for example an eclipse that is extremely low in the sky and would otherwise be blocked by trees. That said, images should generally be cropped to avoid terrestrial objects. This rule also applies to "faked" images depicting phenomenon which are physically impossible to capture on film, [such as animated deep-sky pictures](https://gfycat.com/linearevendrever-space), or the moon superimposed over star trails. In essence, images should be an accurate representation of the object.
-> Images captured with cell phones will be permitted, but only if they follow the rest of the rules of this sub, and clearly represent real effort. While individual shots of a generic starry sky may technically be "astrophotography", they are not broadly interesting to this community. At the same time we recognize that many people get started in this hobby with a cell phone on a tripod using stacking and processing apps on that device, so as long as there's a clear astronomical target represented in the image and all other rules are followed, they are welcome here.
-
-***
-
-(will move to correct position later)
-
-Rule 3:
-
-* Original OC and amateur images only
-
-> A major objective of this community is to foster constructive feedback on images, and that goal is negated by a poster who hasn't actually made the image they have submitted as they will not be able to reply or take feedback into account. This is the only dedicated amateur-only community. There are countless other space-related communities that let you post an image you found online.
-
-> The time limit on reposting an edited version of a submission you made is to keep people from spamming the sub with 18 different versions of the same picture. We would love to see your edit, all we ask is that you wait before posting it. If you made an edit and found your image to be better immediately following your post to the sub, feel free to delete the first post and repost.
-
-***
-
-(will move to correct position later)
-
-Rule 1:
-
-* Types of posts in general
-
-> This sub celebrates amateur astrophotography and will primarily focus on sharing and discussing the work of our members. We're allowing discussion of astrophotography articles as long as they're interesting and promote discussion about astrophotography, but promotion of items for sale or self-promootion of your own website or other extenral channels falls outside of this and will be removed as spam. Equipment posts are allowed in order to allow our members to get feedback about their gear and help others to learn what works well for this hobby. Simple/beginner questions (e.g. "should I get this telescope") should be asked in /r/AskAstrophotography.
-
-* Directly embedded images and links to Astrobin
-
-> This is down to image visibility and usability. Embedding images in the post makes it easier for both mobile and desktop users to view without leaving Reddit, and allows our users to avoid off-site advertisements and bad website design. Astrobin in particular is permitted to be linked to because astrophotographers often include considerable additional detail about their work there, but links must be to the specific object page so users can view it without effort. 
-
-***
-
-Rule 4:
-
-* Titles
-> Simply put, bad titles are annoying. We want to encourage users to upvote posts based on the quality of the image, not the story the title tells. This hopefully leads to better images getting the recognition they deserve. While this may not always appear to work in practice, it has helped significantly over the period it has been in place. Stories about the images belong in the comments section along with your acquisition and processing details, not in the title. Also please keep your list of equipment in a comment on your post per rule 5.
-
-***
-
-Rule 5:
-
-* Acquisition and Processing Details
-
-> Acquisition and processing details are important for much the same reason given in rule 3; you can't give feedback, new users can't research equipment or replicate the image, and discussion is reduced and simplified as a consequence. We don't want to see an image with a bunch of posts saying "nice" in the comments -- we want to see "nice, but this could have been done differently". Acquisition details refers to any hardware used (i.e. telescope, mount, camera), the exposure count/length, and software used for hardware control (e.g. PHD2, backyardEOS). Processing details refer to software used to stack and edit the images (e.g. deepskystacker, PixInsight), and, at a minimum, a basic rundown of processes done. While we don't expect exact number settings for a PixInsight process we do expect the process itself to be mentioned. Posts will be removed without warning if no details have been added after a reasonable amount of time has passed. We know that if you processed an image, you probably used one of several processing programs such as PixInsight or Photoshop, Gimp, etc, to name a few. We want to know what you _did_. Simply saying "processed in PixInsight" is like saying I breathe air. It doesn't add anything to discuss.

--- a/wiki/posting-guidelines-and-rules-explanation/post-titles.md
+++ b/wiki/posting-guidelines-and-rules-explanation/post-titles.md
@@ -44,7 +44,7 @@ Exposure time: e.g "16 Hours" etc.
 
 Date: "Taken on 10/4/18" etc.
 
-Location: "Rocky Mountain National Park" Reposting a newly processed image: Already required, please check out Rule 6.
+Location: "Rocky Mountain National Park"
 
 #### Information discouraged from titles
 


### PR DESCRIPTION
Changes in this PR are intended to incorporate all feedback from new mods in 2024, which were to resurrect the pre-protest ruleset and update them for some current needs. The changes from the pre-protest ruleset here are:

1) renumbering rules to eliminate confusion about which types of posts are and aren't allowed, then describe the details of each. 
2) eliminated secondary section to provide explanations, and instead moved explanations to just below the rule, to reduce duplication and confusion.
3) revised rules regarding landscape and cell phone images to make both permissible under certain conditions that largely boil down to a) must be focused on the actual astronomical object, b) not be low-effort, and c) still provide acquisition/processing details to align with the goals of this community
4) clarify that certain types of images that have been seen lately are not permitted (e.g. suspected UFOs, memes, etc)